### PR TITLE
Created example user factory

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -82,7 +82,7 @@ describe("Authentication & User Account Tests", () => {
 			const res = await request(app).post(url).send(existingUserDetails);
 
 			expect(res.statusCode).toEqual(statusCode.BAD_REQUEST);
-			
+
 			expect(res.body.message).toEqual(
 				"Email already registered. Please login."
 			);

--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -2,6 +2,7 @@ import request from "supertest";
 import app from "../src/utils/app";
 import { HTTP_STATUS as statusCode } from "../src/utils/httpStatus";
 import { clearDB, closeDB, connectDB } from "./testdb";
+import { createTestUser } from "./factories/users.factory";
 
 /**
  * I like these methods, but they feel more like utility functions rather than test code.
@@ -23,6 +24,11 @@ describe("Authentication & User Account Tests", () => {
 	beforeAll(async () => {
 		await connectDB();
 	});
+
+	beforeEach(async () => {
+		await clearDB()
+	})
+
 	afterAll(async () => {
 		await clearDB();
 		await closeDB();
@@ -65,8 +71,18 @@ describe("Authentication & User Account Tests", () => {
 
 		// trying to create an account with the same email as above
 		it("should not create a new user with the same email", async () => {
-			const res = await request(app).post(url).send(payload);
+			const existingUser = await createTestUser()
+
+			const existingUserDetails = {
+				email: existingUser.email,
+				password: "password123",
+				username: existingUser.username
+			}
+
+			const res = await request(app).post(url).send(existingUserDetails);
+
 			expect(res.statusCode).toEqual(statusCode.BAD_REQUEST);
+			
 			expect(res.body.message).toEqual(
 				"Email already registered. Please login."
 			);

--- a/server/__tests__/factories/definitions.ts
+++ b/server/__tests__/factories/definitions.ts
@@ -1,0 +1,4 @@
+interface factoryOptions {
+    traits: Array<string>
+    attributes: Record<string, any>
+}

--- a/server/__tests__/factories/users.factory.ts
+++ b/server/__tests__/factories/users.factory.ts
@@ -1,4 +1,5 @@
 import { createUser } from '../../src/models/user.model'
+import { generateHash } from '../../src/utils/auth'
 
 export async function createTestUser(opts: factoryOptions = {traits: [], attributes: {}}) {
     const attrsToAttach: Record<string, any> = userDefinition()
@@ -23,7 +24,7 @@ export async function createTestUser(opts: factoryOptions = {traits: [], attribu
 function userDefinition(): Record<string, any> {
     const data: Record<string, any> = {
         email: "test@example.com",
-        password: "password123",
+        password: generateHash("password123"),
         username: "testuser",
         // whatever other fields you want here
     }

--- a/server/__tests__/factories/users.factory.ts
+++ b/server/__tests__/factories/users.factory.ts
@@ -1,0 +1,46 @@
+import { createUser } from '../../src/models/user.model'
+
+export async function createTestUser(opts: factoryOptions = {traits: [], attributes: {}}) {
+    const attrsToAttach: Record<string, any> = userDefinition()
+
+    /**
+     * If you decide you don't want traits, you can remove this
+     */
+    if (opts.traits.length > 0) {
+        opts.traits.forEach(trait => attachTrait(trait, attrsToAttach))
+    }
+
+    const userAttrs = Object.assign(attrsToAttach, opts.attributes)
+
+    return await createUser(userAttrs)
+}
+
+/**
+ * This is the basic user definition that will always be used when creating
+ * a user. If you want random data, you could add faker, or use Uuid and access X
+ * number of characters.
+ */
+function userDefinition(): Record<string, any> {
+    const data: Record<string, any> = {
+        email: "test@example.com",
+        password: "password123",
+        username: "testuser",
+        // whatever other fields you want here
+    }
+
+    return data
+}
+
+/**
+ * Traits are for if you want to create templates of data you want on users. 
+ * There are much nicer ways of doing this, but if you're just experimenting, 
+ * this will work for a while.
+ */
+function attachTrait(trait: string, attributes: Record<string, any>) {
+    switch (trait) {
+        case "admin":
+            attributes['email'] = 'admin_user@admin_user.com'
+            break
+        default:
+    }
+}

--- a/server/__tests__/users.controler.test.ts
+++ b/server/__tests__/users.controler.test.ts
@@ -1,0 +1,52 @@
+import { connectDB, clearDB, closeDB } from "./testdb";
+import request from "supertest";
+import app from "../src/utils/app";
+import { createTestUser } from "./factories/users.factory";
+import { HTTP_STATUS } from "../src/utils/httpStatus";
+import { tryPromise } from "../src/utils/inlineHandlers";
+import { getSessionByUserId } from "../src/models/session.model";
+
+
+describe.only("RENAME ME", () => {
+    beforeAll(async () => {
+		await connectDB();
+	});
+
+	beforeEach(async () => {
+		await clearDB()
+	})
+
+	afterAll(async () => {
+		await clearDB();
+		await closeDB();
+	});
+    
+    it("I NEED A NEW NAME", async () => {
+        const { user, sessionToken } = await logInUserAndGetSessionToken();
+
+        const res = await request(app)
+            .put(`/users/${user._id}`)
+            .set("Cookie", [`sessionToken=${sessionToken.data?._id}`])
+            .send({
+                "username": "sillyemail@jester.com",
+                "password": "newPassddd"
+            });
+
+        expect(res.statusCode).toBe(HTTP_STATUS.OK)
+    })
+})
+
+// Maybe refactor this a bit and move to a helper func
+async function logInUserAndGetSessionToken() {
+    const user = await createTestUser();
+
+    const login = await request(app).post("/auth/login").send({
+        "email": user.email,
+        "password": "password123"
+    });
+
+    expect(login.statusCode).toBe(HTTP_STATUS.OK);
+
+    const sessionToken = await tryPromise(getSessionByUserId(user._id as unknown as string));
+    return { user, sessionToken };
+}

--- a/server/src/utils/inlineHandlers.ts
+++ b/server/src/utils/inlineHandlers.ts
@@ -24,9 +24,9 @@ export async function tryPromise<T>(func: Promise<T>): Promise<Try<T>> {
 
 export function trySync<T>(func: Function): Try<T> {
 	try {
-		return <Try<any>>{ data: func(), error: null };
+		return <Try<T>>{ data: func(), error: null };
 	} catch (error) {
-		const result = <Try<any>>{ data: null, error };
+		const result = <Try<T>>{ data: null, error };
 		// console.error(result.error?.message);
 
 		return result;


### PR DESCRIPTION
## Changelog
- Added user factory with example admin trait
- Added beforeEach hook to test to clear out old data from previous tests
- Use factory in test `POST /auth/signup > should not create a new user with the same email`

### Notes
- Factory example is simple. Could be made into an abstract class so that making more factories later is easier. Didn't do this to avoid adding cruft you may not use and also maintain your current approach of preferring functions over classes in your files
